### PR TITLE
refactor: Refactor WithCustomClaimContainsRule to accept an array

### DIFF
--- a/rules_test.go
+++ b/rules_test.go
@@ -166,10 +166,10 @@ func TestWithCustomClaimExactMatchRule(t *testing.T) {
 
 func TestWithCustomClaimContainsRule(t *testing.T) {
 	cases := map[string]struct {
-		claim     string
-		claims    map[string]any
-		wantValue string
-		wantErr   string
+		claim      string
+		claims     map[string]any
+		wantValues []string
+		wantErr    string
 	}{
 		"wrong type": {
 			claim: "foo",
@@ -181,23 +181,23 @@ func TestWithCustomClaimContainsRule(t *testing.T) {
 		"fails validation": {
 			claim: "foo",
 			claims: map[string]any{
-				"foo": []any{"bar", "hello"},
+				"foo": []any{"bar", "hello", "world"},
 			},
-			wantValue: "world",
-			wantErr:   "value 'world' not present in claim",
+			wantValues: []string{"world", "lmao", "haha"},
+			wantErr:    "missing value(s): 'lmao', 'haha'",
 		},
 		"passes validation": {
 			claim: "foo",
 			claims: map[string]any{
-				"foo": []any{"bar", "hello"},
+				"foo": []any{"bar", "hello", "world"},
 			},
-			wantValue: "bar",
+			wantValues: []string{"world", "bar"},
 		},
 	}
 
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
-			rule := WithCustomClaimContainsRule(tt.claim, tt.wantValue)
+			rule := WithCustomClaimContainsRule(tt.claim, tt.wantValues)
 			require.Equal(t, rule.Key, tt.claim)
 
 			err := rule.Rule(tt.claims[rule.Key])


### PR DESCRIPTION
Refactors WithCustomClaimContainsRule so that rather than accepting a single value, it accepts an array, and changes the behavior so that it will only return a nil error if all of the provided values are present in the claim values.